### PR TITLE
Simplified healthcheck command. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Using the `healthcheck` parameter the use of these additional tools and scripts 
 A particularly common use case is a service that depends on a database, such as PostgreSQL.
 We can configure docker-compose to wait for the PostgreSQL container to startup and be ready to accept requests before continuing.
 
-The following healthcheck has been configured to periodically check if PostgreSQL reponds to the `\l` list query.
+The following healthcheck has been configured to periodically check if PostgreSQL is ready using the `pg_isready` command, see the documentation [here](https://www.postgresql.org/docs/9.4/static/app-pg-isready.html).
 ```
 healthcheck:
-  test: ["CMD-SHELL", "psql -h 'localhost' -U 'postgres' -c '\\l'"]
+  test: ["CMD-SHELL", "pg_isready"]
   interval: 30s
   timeout: 30s
   retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_USER=kong
       - POSTGRES_DB=kong
     healthcheck:
-      test: ["CMD-SHELL", "psql -h 'localhost' -U 'postgres' -c '\\l'"]
+      test: ["CMD-SHELL", "pg_isready"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
I was implementing a docker-compose healthcheck for one of my services that uses PostgreSQL. I did find on Postgres's website that they support the `pg_isready` command. When I was looking for solutions how to write the healthcheck syntax in `docker-compose.yml` I stumbled upon your git-repo. I think the minor change to look for `pg_isready` may be easier to understand since the current way the healthcheck is done is by looking for a query result. 

This works as of PostgreSQL version 9.3 (docker-compose.yml uses postgre v. 9.4). 