### PR TITLE
Correct the CMD-SHELL command to not flood logs with root error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We can configure docker-compose to wait for the PostgreSQL container to startup 
 The following healthcheck has been configured to periodically check if PostgreSQL is ready using the `pg_isready` command. See the documentation for the `pg_isready` command [here](https://www.postgresql.org/docs/9.4/static/app-pg-isready.html).
 ```
 healthcheck:
-  test: ["CMD-SHELL", "pg_isready"]
+  test: ["CMD-SHELL", "pg_isready -U postgres"]
   interval: 30s
   timeout: 30s
   retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_USER=kong
       - POSTGRES_DB=kong
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 30s
       timeout: 30s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,4 +31,3 @@ services:
     environment:
       - KONG_DATABASE=postgres
       - KONG_PG_HOST=kong-database
-  


### PR DESCRIPTION
This PR corrects the healthcheck CMD-SHELL command so that it is executed by the `postgres` user, and not the `root` user (or whatever user is "active" in your container).

Fixes #4.