### PR TITLE
Use an existing user for the pg_isready check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_DB=kong
       - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U kong"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This project was super helpful to me in learning that the depends_on condition was available again in docker-compose. I just noticed the db healthcheck was using the postgres user which doesn't exist and prints an error to the logs. Not a huge deal. I mostly just wanted to say thank you.