### PR TITLE
Remove pg_isready args

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We can configure docker-compose to wait for the PostgreSQL container to startup 
 The following healthcheck has been configured to periodically check if PostgreSQL is ready using the `pg_isready` command. See the documentation for the `pg_isready` command [here](https://www.postgresql.org/docs/9.4/static/app-pg-isready.html).
 ```yml
 healthcheck:
-  test: ["CMD-SHELL", "pg_isready -U postgres"]
+  test: ["CMD-SHELL", "pg_isready"]
   interval: 10s
   timeout: 5s
   retries: 5

--- a/README_JP.md
+++ b/README_JP.md
@@ -17,7 +17,7 @@ PostgreSQLコンテナが起動し、リクエストを受け入れる準備が�
 以下の例では、`pg_isready`コマンドを使用してPostgreSQLが使用可能かどうかを定期的にチェックするように設定されています。[`pg_isready`コマンドの参照](https://www.postgresql.org/docs/9.4/static/app-pg-isready.html)
 ```yml
 healthcheck:
-  test: ["CMD-SHELL", "pg_isready -U postgres"]
+  test: ["CMD-SHELL", "pg_isready"]
   interval: 10s
   timeout: 5s
   retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_DB=kong
       - POSTGRES_HOST_AUTH_METHOD=trust
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Removing the args to specify the user because they are not required by `pg_isready` to return the status.